### PR TITLE
Support for "After declared, before revealed" windows

### DIFF
--- a/server/game/Constants.ts
+++ b/server/game/Constants.ts
@@ -278,6 +278,7 @@ export enum EventNames {
     OnGloryCount = 'onGloryCount',
     OnClaimFavor = 'onClaimFavor',
     OnConflictMoved = 'onConflictMoved',
+    OnConflictAnnounced = 'onConflictAnnounced',
     Unnamed = 'unnamedEvent'
 };
 

--- a/server/game/cards/01-Core/EndlessPlains.js
+++ b/server/game/cards/01-Core/EndlessPlains.js
@@ -6,7 +6,7 @@ class EndlessPlains extends ProvinceCard {
         this.reaction({
             title: 'Force opponent to discard a character',
             when: {
-                onConflictDeclared: (event, context) => event.conflict.conflictProvince === context.source
+                onConflictDeclared: (event, context) => event.conflict.declaredProvince === context.source
             },
             cost: ability.costs.breakSelf(),
             target: {

--- a/server/game/cards/01-Core/SecretCache.js
+++ b/server/game/cards/01-Core/SecretCache.js
@@ -5,7 +5,7 @@ class SecretCache extends ProvinceCard {
         this.reaction({
             title: 'Look at top 5 cards',
             when: {
-                onConflictDeclared: (event, context) => event.conflict.conflictProvince === context.source
+                onConflictDeclared: (event, context) => event.conflict.declaredProvince === context.source
             },
             effect: 'look at the top 5 cards of their conflict deck',
             gameAction: ability.actions.deckSearch({ amount: 5, reveal: false })

--- a/server/game/cards/04.1-BotK/SacredSanctuary.js
+++ b/server/game/cards/04.1-BotK/SacredSanctuary.js
@@ -6,7 +6,7 @@ class SacredSanctuary extends ProvinceCard {
         this.reaction({
             title: 'Choose a monk character',
             when: {
-                onConflictDeclared: (event, context) => event.conflict.conflictProvince === context.source
+                onConflictDeclared: (event, context) => event.conflict.declaredProvince === context.source
             },
             target: {
                 cardType: CardTypes.Character,

--- a/server/game/cards/06-CotE/MidnightRevels.js
+++ b/server/game/cards/06-CotE/MidnightRevels.js
@@ -7,7 +7,7 @@ class MidnightRevels extends ProvinceCard {
         this.reaction({
             title: 'Bow a character',
             when: {
-                onConflictDeclared: (event, context) => event.conflict.conflictProvince === context.source
+                onConflictDeclared: (event, context) => event.conflict.declaredProvince === context.source
             },
             target: {
                 cardType: CardTypes.Character,

--- a/server/game/cards/09.4-TCoH/FortifiedAssembly.js
+++ b/server/game/cards/09.4-TCoH/FortifiedAssembly.js
@@ -7,7 +7,7 @@ class FortifiedAssembly extends ProvinceCard {
         this.reaction({
             title: 'Place an honor token on this province',
             when: {
-                onConflictDeclared: (event, context) => event.conflict.conflictProvince === context.source
+                onConflictDeclared: (event, context) => event.conflict.declaredProvince === context.source
             },
             gameAction: AbilityDsl.actions.addToken(),
             effect: 'put an honor token on {0}',

--- a/server/game/cards/09.6-SD/KnowTheTerrain.js
+++ b/server/game/cards/09.6-SD/KnowTheTerrain.js
@@ -1,0 +1,40 @@
+const DrawCard = require('../../drawcard.js');
+const { CardTypes, Players, Locations } = require('../../Constants');
+
+class KnowTheTerrain extends DrawCard {
+    setupCardAbilities() {
+        this.wouldInterrupt({
+            title: 'Switch the attacked province with a facedown province',
+            effect: 'switch the attacked province card',
+            when: {
+                onConflictAnnounced: (event, context) => event.conflict.conflictProvince.facedown &&
+                    context.player.isDefendingPlayer() &&
+                    event.conflict.conflictProvince.location !== Locations.StrongholdProvince
+            },
+            handler: context => this.game.promptForSelect(context.player, {
+                activePromptTitle: 'Choose an unbroken province',
+                cardType: CardTypes.Province,
+                location: Locations.Provinces,
+                controller: Players.Self,
+                cardCondition: card => card.location !== Locations.StrongholdProvince && !card.isBroken && card.facedown && card !== this.game.currentConflict.conflictProvince,
+                onSelect: (player, card) => {
+                    let attackedprovince = this.game.currentConflict.conflictProvince;
+                    let chosenProvince = card;
+                    let attackedLocation = attackedprovince.location;
+                    let chosenLocation = chosenProvince.location;
+                    context.player.moveCard(attackedprovince, chosenLocation);
+                    context.player.moveCard(chosenProvince, attackedLocation);
+
+                    chosenProvince.inConflict = true;
+                    this.game.currentConflict.conflictProvince.inConflict = false;
+                    this.game.currentConflict.conflictProvince = chosenProvince;
+                    return true;
+                }
+            })
+        });
+    }
+}
+
+KnowTheTerrain.id = 'know-the-terrain';
+
+module.exports = KnowTheTerrain;

--- a/server/game/cards/12-SoW/FuchiMura.js
+++ b/server/game/cards/12-SoW/FuchiMura.js
@@ -6,7 +6,7 @@ class FuchiMura extends ProvinceCard {
         this.reaction({
             title: 'Place one fate on each unclaimed ring',
             when: {
-                onConflictDeclared: (event, context) => event.conflict.conflictProvince === context.source
+                onConflictDeclared: (event, context) => event.conflict.declaredProvince === context.source
             },
             gameAction: AbilityDsl.actions.placeFateOnRing(context =>
                 ({ target: Object.values(context.game.rings).filter(ring => ring.isUnclaimed()) }))

--- a/server/game/cards/13-CW/TempleOfDaikoku.js
+++ b/server/game/cards/13-CW/TempleOfDaikoku.js
@@ -11,7 +11,7 @@ class TempleOfDaikoku extends ProvinceCard {
         this.forcedReaction({
             title: 'Place one fate on the unclaimed water ring',
             when: {
-                onConflictDeclared: (event, context) => event.conflict.conflictProvince === context.source && context.game.rings.water.isUnclaimed()
+                onConflictDeclared: (event, context) => event.conflict.declaredProvince === context.source && context.game.rings.water.isUnclaimed()
             },
             gameAction: AbilityDsl.actions.placeFateOnRing(context => ({ target: context.game.rings.water }))
         });

--- a/server/game/cards/13-CW/TempleOfJikoju.js
+++ b/server/game/cards/13-CW/TempleOfJikoju.js
@@ -11,7 +11,7 @@ class TempleOfJikoju extends ProvinceCard {
         this.forcedReaction({
             title: 'Place one fate on the unclaimed air ring',
             when: {
-                onConflictDeclared: (event, context) => event.conflict.conflictProvince === context.source && context.game.rings.air.isUnclaimed()
+                onConflictDeclared: (event, context) => event.conflict.declaredProvince === context.source && context.game.rings.air.isUnclaimed()
             },
             gameAction: AbilityDsl.actions.placeFateOnRing(context => ({ target: context.game.rings.air }))
         });

--- a/server/game/cards/13-CW/TempleOfOsanoWo.js
+++ b/server/game/cards/13-CW/TempleOfOsanoWo.js
@@ -11,7 +11,7 @@ class TempleOfOsanoWo extends ProvinceCard {
         this.forcedReaction({
             title: 'Place one fate on the unclaimed earth ring',
             when: {
-                onConflictDeclared: (event, context) => event.conflict.conflictProvince === context.source && context.game.rings.earth.isUnclaimed()
+                onConflictDeclared: (event, context) => event.conflict.declaredProvince === context.source && context.game.rings.earth.isUnclaimed()
             },
             gameAction: AbilityDsl.actions.placeFateOnRing(context => ({ target: context.game.rings.earth }))
         });

--- a/server/game/cards/13-CW/TempleOfShinseisWisdom.js
+++ b/server/game/cards/13-CW/TempleOfShinseisWisdom.js
@@ -11,7 +11,7 @@ class TempleOfShinseisWisdom extends ProvinceCard {
         this.forcedReaction({
             title: 'Place one fate on the unclaimed void ring',
             when: {
-                onConflictDeclared: (event, context) => event.conflict.conflictProvince === context.source && context.game.rings.void.isUnclaimed()
+                onConflictDeclared: (event, context) => event.conflict.declaredProvince === context.source && context.game.rings.void.isUnclaimed()
             },
             gameAction: AbilityDsl.actions.placeFateOnRing(context => ({ target: context.game.rings.void }))
         });

--- a/server/game/cards/13-CW/TempleOfTheThunders.js
+++ b/server/game/cards/13-CW/TempleOfTheThunders.js
@@ -11,7 +11,7 @@ class TempleOfTheThunders extends ProvinceCard {
         this.forcedReaction({
             title: 'Place one fate on the unclaimed fire ring',
             when: {
-                onConflictDeclared: (event, context) => event.conflict.conflictProvince === context.source && context.game.rings.fire.isUnclaimed()
+                onConflictDeclared: (event, context) => event.conflict.declaredProvince === context.source && context.game.rings.fire.isUnclaimed()
             },
             gameAction: AbilityDsl.actions.placeFateOnRing(context => ({ target: context.game.rings.fire }))
         });

--- a/server/game/conflict.js
+++ b/server/game/conflict.js
@@ -16,6 +16,7 @@ class Conflict extends GameObject {
         this.declarationComplete = false;
         this.defendersChosen = false;
         this.conflictProvince = conflictProvince;
+        this.declaredProvince = conflictProvince;
         this.conflictPassed = false;
         this.conflictTypeSwitched = false;
         this.conflictUnopposed = false;

--- a/test/server/cards/09.6-SD/KnowTheTerrain.spec.js
+++ b/test/server/cards/09.6-SD/KnowTheTerrain.spec.js
@@ -1,0 +1,311 @@
+describe('Know the Terrain', function() {
+    integration(function() {
+        describe('Know the Terrain\'s ability', function() {
+            beforeEach(function() {
+                this.setupTest({
+                    phase: 'conflict',
+                    player1: {
+                        inPlay: ['border-rider', 'guest-of-honor'],
+                        hand: ['know-the-terrain', 'chasing-the-sun']
+                    },
+                    player2: {
+                        inPlay: ['doji-whisperer'],
+                        hand: ['know-the-terrain', 'talisman-of-the-sun'],
+                        provinces: ['endless-plains', 'rally-to-the-cause', 'secret-cache', 'manicured-garden'],
+                        role: 'keeper-of-void'
+                    }
+                });
+                this.endless = this.player2.findCardByName('endless-plains');
+                this.rally = this.player2.findCardByName('rally-to-the-cause');
+                this.cache = this.player2.findCardByName('secret-cache');
+                this.garden = this.player2.findCardByName('manicured-garden');
+                this.shameful = this.player2.findCardByName('shameful-display', 'stronghold province');
+
+                this.rider = this.player1.findCardByName('border-rider');
+                this.p1Terrain = this.player1.findCardByName('know-the-terrain');
+                this.chasing = this.player1.findCardByName('chasing-the-sun');
+
+                this.whisperer = this.player2.findCardByName('doji-whisperer');
+                this.p2Terrain = this.player2.findCardByName('know-the-terrain');
+                this.talisman = this.player2.findCardByName('talisman-of-the-sun');
+
+                this.player1.pass();
+                this.player2.playAttachment(this.talisman, this.whisperer);
+                this.noMoreActions();
+            });
+
+            it('should interrupt the province being revealed if it is facedown', function() {
+                this.initiateConflict({
+                    type: 'military',
+                    attackers: [this.rider],
+                    province: this.rally
+                });
+                expect(this.player2).toHavePrompt('Triggered Abilities');
+                expect(this.player2).toBeAbleToSelect(this.p2Terrain);
+                expect(this.rally.facedown).toBe(true);
+            });
+
+            it('should not interrupt the province being revealed if it is faceup', function() {
+                this.rally.facedown = false;
+                this.initiateConflict({
+                    type: 'military',
+                    attackers: [this.rider],
+                    province: this.rally
+                });
+                expect(this.player2).toHavePrompt('Choose Defenders');
+                expect(this.rally.facedown).toBe(false);
+            });
+
+            it('should not interrupt the province being revealed if it is the stronghold province', function() {
+                this.rally.isBroken = true;
+                this.cache.isBroken = true;
+                this.garden.isBroken = true;
+                this.initiateConflict({
+                    type: 'military',
+                    attackers: [this.rider],
+                    province: this.shameful
+                });
+                expect(this.player2).toHavePrompt('Choose Defenders');
+                expect(this.shameful.facedown).toBe(false);
+            });
+
+            it('should not interrupt a province being revealed after conflict declaration', function() {
+                this.rally.facedown = false;
+                this.initiateConflict({
+                    type: 'military',
+                    attackers: [this.rider],
+                    defenders: [],
+                    province: this.rally
+                });
+
+                this.player2.clickCard(this.talisman);
+                this.player2.clickCard(this.endless);
+                expect(this.player2).toHavePrompt('Waiting for opponent to take an action or pass');
+                expect(this.player1).toHavePrompt('Conflict Action Window');
+            });
+
+            it('should let you select a facedown unbroken non-stronghold province that is not being attacked', function() {
+                this.initiateConflict({
+                    type: 'military',
+                    attackers: [this.rider],
+                    province: this.rally
+                });
+                expect(this.player2).toHavePrompt('Triggered Abilities');
+                expect(this.player2).toBeAbleToSelect(this.p2Terrain);
+                expect(this.rally.facedown).toBe(true);
+                this.player2.clickCard(this.p2Terrain);
+                expect(this.player2).not.toBeAbleToSelect(this.rally);
+                expect(this.player2).toBeAbleToSelect(this.endless);
+                expect(this.player2).toBeAbleToSelect(this.cache);
+                expect(this.player2).toBeAbleToSelect(this.garden);
+                expect(this.player2).not.toBeAbleToSelect(this.shameful);
+            });
+
+            it('should not let you select faceup or broken provinces', function() {
+                this.cache.facedown = false;
+                this.endless.facedown = false;
+                this.endless.isBroken = true;
+                this.initiateConflict({
+                    type: 'military',
+                    attackers: [this.rider],
+                    province: this.rally
+                });
+                expect(this.player2).toHavePrompt('Triggered Abilities');
+                expect(this.player2).toBeAbleToSelect(this.p2Terrain);
+                expect(this.rally.facedown).toBe(true);
+                this.player2.clickCard(this.p2Terrain);
+                expect(this.player2).not.toBeAbleToSelect(this.rally);
+                expect(this.player2).not.toBeAbleToSelect(this.endless);
+                expect(this.player2).not.toBeAbleToSelect(this.cache);
+                expect(this.player2).toBeAbleToSelect(this.garden);
+                expect(this.player2).not.toBeAbleToSelect(this.shameful);
+            });
+
+            it('should switch the provinces', function() {
+                let rallyLocation = this.rally.location;
+                let gardenLocation = this.garden.location;
+
+                this.initiateConflict({
+                    type: 'military',
+                    attackers: [this.rider],
+                    province: this.rally
+                });
+                expect(this.player2).toHavePrompt('Triggered Abilities');
+                expect(this.player2).toBeAbleToSelect(this.p2Terrain);
+                expect(this.rally.facedown).toBe(true);
+                this.player2.clickCard(this.p2Terrain);
+                expect(this.player2).not.toBeAbleToSelect(this.rally);
+                expect(this.player2).toBeAbleToSelect(this.endless);
+                expect(this.player2).toBeAbleToSelect(this.cache);
+                expect(this.player2).toBeAbleToSelect(this.garden);
+                expect(this.player2).not.toBeAbleToSelect(this.shameful);
+
+                this.player2.clickCard(this.garden);
+                expect(this.rally.facedown).toBe(true);
+                expect(this.garden.facedown).toBe(false);
+                expect(this.rally.location).toBe(gardenLocation);
+                expect(this.garden.location).toBe(rallyLocation);
+                expect(this.getChatLogs(3)).toContain('player2 plays Know the Terrain to switch the attacked province card');
+                expect(this.getChatLogs(2)).toContain('player1 is initiating a military conflict at Manicured Garden, contesting Air Ring');
+            });
+
+            it('should allow reactions on the new provinces to be used', function() {
+                this.initiateConflict({
+                    type: 'military',
+                    attackers: [this.rider],
+                    province: this.rally
+                });
+                expect(this.player2).toHavePrompt('Triggered Abilities');
+                expect(this.player2).toBeAbleToSelect(this.p2Terrain);
+                expect(this.rally.facedown).toBe(true);
+                this.player2.clickCard(this.p2Terrain);
+                expect(this.player2).not.toBeAbleToSelect(this.rally);
+                expect(this.player2).toBeAbleToSelect(this.endless);
+                expect(this.player2).toBeAbleToSelect(this.cache);
+                expect(this.player2).toBeAbleToSelect(this.garden);
+                expect(this.player2).not.toBeAbleToSelect(this.shameful);
+
+                this.player2.clickCard(this.cache);
+                expect(this.player2).toHavePrompt('Triggered Abilities');
+                this.player2.clickCard(this.cache);
+                expect(this.player2).toHavePrompt('Select a card to put in your hand');
+            });
+        });
+
+        describe('Checking edge case interactions', function() {
+            beforeEach(function() {
+                this.setupTest({
+                    phase: 'draw',
+                    player1: {
+                        inPlay: ['master-of-gisei-toshi', 'guest-of-honor', 'ikoma-kiyono', 'kitsuki-yuikimi'],
+                        hand: ['castigated'],
+                        conflictDiscard: ['forged-edict']
+                    },
+                    player2: {
+                        hand: ['know-the-terrain'],
+                        provinces: ['endless-plains', 'rally-to-the-cause', 'secret-cache', 'manicured-garden'],
+                        role: 'keeper-of-void'
+                    }
+                });
+                this.endless = this.player2.findCardByName('endless-plains');
+                this.rally = this.player2.findCardByName('rally-to-the-cause');
+                this.cache = this.player2.findCardByName('secret-cache');
+                this.garden = this.player2.findCardByName('manicured-garden');
+                this.shameful = this.player2.findCardByName('shameful-display', 'stronghold province');
+
+                this.gisei = this.player1.findCardByName('master-of-gisei-toshi');
+                this.yuikimi = this.player1.findCardByName('kitsuki-yuikimi');
+                this.guest = this.player1.findCardByName('guest-of-honor');
+                this.kiyono = this.player1.findCardByName('ikoma-kiyono');
+                this.castigated = this.player1.findCardByName('castigated');
+                this.edict = this.player1.findCardByName('forged-edict');
+
+                this.terrain = this.player2.findCardByName('know-the-terrain');
+
+                this.player1.clickPrompt('1');
+                this.player2.clickPrompt('1');
+
+                this.noMoreActions();
+
+                this.player1.clickCard(this.gisei);
+                this.player1.clickRing('fire');
+                this.kiyono.attachments.push(this.castigated);
+                this.game.rings.void.fate = 1;
+            });
+
+            it('guest should not prevent triggering (characters should not be participating yet)', function() {
+                this.noMoreActions();
+                this.initiateConflict({
+                    type: 'military',
+                    attackers: [this.guest],
+                    province: this.rally
+                });
+                expect(this.player2).toHavePrompt('Triggered Abilities');
+                expect(this.player2).toBeAbleToSelect(this.p2Terrain);
+                expect(this.rally.facedown).toBe(true);
+                this.player2.clickCard(this.p2Terrain);
+                expect(this.player2).toHavePrompt('Know The Terrain');
+                expect(this.player2).not.toBeAbleToSelect(this.shameful);
+            });
+
+            it('gisei toshi should not prevent triggering (ring should not be contested yet)', function() {
+                this.noMoreActions();
+                this.initiateConflict({
+                    type: 'military',
+                    attackers: [this.gisei],
+                    province: this.rally,
+                    ring: 'fire'
+                });
+                expect(this.player2).toHavePrompt('Triggered Abilities');
+                expect(this.player2).toBeAbleToSelect(this.p2Terrain);
+                expect(this.rally.facedown).toBe(true);
+                this.player2.clickCard(this.p2Terrain);
+                expect(this.player2).toHavePrompt('Know The Terrain');
+                expect(this.player2).toBeAbleToSelect(this.cache);
+            });
+
+            it('should trigger before fate is taken from rings', function() {
+                let fate = this.player1.fate;
+
+                this.noMoreActions();
+                this.initiateConflict({
+                    type: 'military',
+                    attackers: [this.gisei],
+                    province: this.rally,
+                    ring: 'void'
+                });
+                expect(this.player2).toHavePrompt('Triggered Abilities');
+                expect(this.player2).toBeAbleToSelect(this.p2Terrain);
+                expect(this.rally.facedown).toBe(true);
+                this.player2.clickCard(this.p2Terrain);
+                expect(this.player2).toHavePrompt('Know The Terrain');
+                expect(this.player2).toBeAbleToSelect(this.cache);
+
+                expect(this.player1.fate).toBe(fate);
+            });
+
+            it('should trigger before Yuikimi', function() {
+                this.noMoreActions();
+                this.initiateConflict({
+                    type: 'military',
+                    attackers: [this.yuikimi],
+                    province: this.rally,
+                    ring: 'void'
+                });
+                expect(this.player2).toHavePrompt('Triggered Abilities');
+                expect(this.player2).toBeAbleToSelect(this.p2Terrain);
+                expect(this.rally.facedown).toBe(true);
+                this.player2.clickCard(this.p2Terrain);
+                expect(this.player2).toHavePrompt('Know The Terrain');
+                expect(this.player2).toBeAbleToSelect(this.cache);
+            });
+
+            it('should fizzle the conflict if your only attacker dies', function() {
+                let fate = this.player1.fate;
+                this.player1.moveCard(this.edict, 'hand');
+                this.initiateConflict({
+                    type: 'military',
+                    attackers: [this.kiyono],
+                    province: this.rally,
+                    ring: 'void'
+                });
+                expect(this.player2).toHavePrompt('Triggered Abilities');
+                expect(this.player2).toBeAbleToSelect(this.p2Terrain);
+                expect(this.rally.facedown).toBe(true);
+                this.player2.clickCard(this.p2Terrain);
+                expect(this.player2).toHavePrompt('Know The Terrain');
+                expect(this.player2).toBeAbleToSelect(this.cache);
+                this.player2.clickCard(this.cache);
+
+                expect(this.player1).toHavePrompt('Triggered Abilities');
+                expect(this.player1).toBeAbleToSelect(this.edict);
+                this.player1.clickCard(this.edict);
+                this.player1.clickCard(this.kiyono);
+                expect (this.kiyono.location).toBe('dynasty discard pile');
+                expect(this.player1.fate).toBe(fate);
+
+                expect(this.getChatLogs(3)).toContain('fizzle message');
+            });
+        });
+    });
+});

--- a/test/server/cards/12-SoW/VineTattoo.spec.js
+++ b/test/server/cards/12-SoW/VineTattoo.spec.js
@@ -205,7 +205,7 @@ describe('Vine Tattoo', function() {
             expect(this.player1).toHavePrompt('Triggered Abilities');
             expect(this.player1).toBeAbleToSelect(this.tengu);
             this.player1.clickCard(this.tengu);
-            expect(this.getChatLogs(3)).toContain('player1 uses Tengu Sensei to prevent Master Alchemist from attacking this phase');
+            expect(this.getChatLogs(4)).toContain('player1 uses Tengu Sensei to prevent Master Alchemist from attacking this phase');
         });
 
         it('Covert Test - reaction to covert should be on the right target (switching selection order)', function() {
@@ -222,7 +222,7 @@ describe('Vine Tattoo', function() {
             expect(this.player1).toHavePrompt('Triggered Abilities');
             expect(this.player1).toBeAbleToSelect(this.tengu);
             this.player1.clickCard(this.tengu);
-            expect(this.getChatLogs(3)).toContain('player1 uses Tengu Sensei to prevent Master Alchemist from attacking this phase');
+            expect(this.getChatLogs(4)).toContain('player1 uses Tengu Sensei to prevent Master Alchemist from attacking this phase');
         });
     });
 });

--- a/test/server/integration/conflictphase.spec.js
+++ b/test/server/integration/conflictphase.spec.js
@@ -458,7 +458,7 @@ describe('conflict phase', function() {
                 });
                 expect(this.player1.player.fate).toBe(fate + 2);
                 expect(this.game.rings.fire.fate).toBe(0);
-                expect(this.getChatLogs(1)).toContain('player1 takes 2 fate from Fire Ring');
+                expect(this.getChatLogs(2)).toContain('player1 takes 2 fate from Fire Ring');
             });
 
             it('should reveal the province', function() {


### PR DESCRIPTION
Modified conflict flow to have two nested event windows, with the inner one encompassing the declaration itself while the outer one includes the original "onConflictDeclared" and "onProvinceReveal" events. 

The inner event window is called "onConflictAnnounced", and corresponds to the new "When a conflict is declared but before the province is revealed" timing window. The attacker removes fate from rings within this window. 
