### PR TITLE
Dev - Bugfixes for Field of Ruin & Cycle of Rebirth

### DIFF
--- a/server/game/cards/14.1-RaW/CycleOfRebirth.js
+++ b/server/game/cards/14.1-RaW/CycleOfRebirth.js
@@ -13,16 +13,44 @@ class CycleOfRebirth extends DrawCard {
                 cardCondition: card => card.type !== CardTypes.Province && card.type !== CardTypes.Stronghold
             },
             gameAction: AbilityDsl.actions.sequential([
-                AbilityDsl.actions.moveCard(context => ({
-                    destination: Locations.DynastyDeck,
-                    target: [context.target, context.source],
-                    shuffle: true
-                })),
+                AbilityDsl.actions.conditional({
+                    condition: context => context.target.controller === context.source.controller,
+                    trueGameAction: AbilityDsl.actions.moveCard(context => ({
+                        destination: Locations.DynastyDeck,
+                        target: [context.target, context.source],
+                        shuffle: true
+                    })),
+                    falseGameAction: AbilityDsl.actions.multiple([
+                        AbilityDsl.actions.moveCard(context => ({
+                            destination: Locations.DynastyDeck,
+                            target: context.target,
+                            shuffle: true
+                        })),
+                        AbilityDsl.actions.moveCard(context => ({
+                            destination: Locations.DynastyDeck,
+                            target: context.source,
+                            shuffle: true
+                        }))
+                    ])
+                }),
                 AbilityDsl.actions.refillFaceup(context => ({
                     target: [context.target.controller, context.source.controller],
                     location: [Locations.ProvinceOne, Locations.ProvinceTwo, Locations.ProvinceThree, Locations.ProvinceFour]
                 }))
-            ])
+            ]),
+            effect: 'shuffle {1}{3}{4} into {2}\'s dynasty deck{5}{6}{7}{8}{9}',
+            effectArgs: context => [
+                context.target,
+                context.target.controller,
+                context.target.controller === context.source.controller ? ' and ' : '',
+                context.target.controller === context.source.controller ? context.source : '',
+                context.target.controller !== context.source.controller ? '. ' : '',
+                context.target.controller !== context.source.controller ? context.source : '',
+                context.target.controller !== context.source.controller ? ' is shuffled into ' : '',
+                context.target.controller !== context.source.controller ? context.source.controller : '',
+                context.target.controller !== context.source.controller ? '\'s dynasty deck' : '',
+                context.source.controller
+            ]
         });
     }
 }

--- a/server/game/cards/14.1-RaW/CycleOfRebirth.js
+++ b/server/game/cards/14.1-RaW/CycleOfRebirth.js
@@ -13,26 +13,18 @@ class CycleOfRebirth extends DrawCard {
                 cardCondition: card => card.type !== CardTypes.Province && card.type !== CardTypes.Stronghold
             },
             gameAction: AbilityDsl.actions.sequential([
-                AbilityDsl.actions.conditional({
-                    condition: context => context.target.controller === context.source.controller,
-                    trueGameAction: AbilityDsl.actions.moveCard(context => ({
+                AbilityDsl.actions.multiple([
+                    AbilityDsl.actions.moveCard(context => ({
                         destination: Locations.DynastyDeck,
-                        target: [context.target, context.source],
+                        target: context.target,
                         shuffle: true
                     })),
-                    falseGameAction: AbilityDsl.actions.multiple([
-                        AbilityDsl.actions.moveCard(context => ({
-                            destination: Locations.DynastyDeck,
-                            target: context.target,
-                            shuffle: true
-                        })),
-                        AbilityDsl.actions.moveCard(context => ({
-                            destination: Locations.DynastyDeck,
-                            target: context.source,
-                            shuffle: true
-                        }))
-                    ])
-                }),
+                    AbilityDsl.actions.moveCard(context => ({
+                        destination: Locations.DynastyDeck,
+                        target: context.source,
+                        shuffle: true
+                    }))
+                ]),
                 AbilityDsl.actions.refillFaceup(context => ({
                     target: [context.target.controller, context.source.controller],
                     location: [Locations.ProvinceOne, Locations.ProvinceTwo, Locations.ProvinceThree, Locations.ProvinceFour]

--- a/server/game/cards/14.1-RaW/FieldOfRuin.js
+++ b/server/game/cards/14.1-RaW/FieldOfRuin.js
@@ -22,7 +22,7 @@ class FieldOfRuin extends DrawCard {
                 onPhaseStarted: event => event.phase === Phases.Conflict
             },
             gameAction: AbilityDsl.actions.discardCard(context => ({
-                target: context.source.controller.getDynastyCardsInProvince(context.source.parent.location)
+                target: context.source.parent.controller.getDynastyCardsInProvince(context.source.parent.location)
             })),
             effect: 'discard each card in the attached province'
         });

--- a/test/server/cards/14.1-RaW/CycleOfRebirth.spec.js
+++ b/test/server/cards/14.1-RaW/CycleOfRebirth.spec.js
@@ -55,6 +55,7 @@ describe('Cycle of Rebirth', function() {
                 this.player1.clickCard(this.zentaro);
 
                 expect(this.getChatLogs(3)).toContain('player1 plays Cycle of Rebirth to shuffle Akodo Zentarō and Cycle of Rebirth into player1\'s dynasty deck');
+                expect(this.getChatLogs(3)).toContain('player1 is shuffling their dynasty deck');
                 expect(this.cycleOfRebirth.location).not.toBe('dynasty discard pile');
             });
 
@@ -70,6 +71,18 @@ describe('Cycle of Rebirth', function() {
 
                 expect(this.player1.player.getDynastyCardsInProvince(zentaroLocation).every(card => card.facedown === false)).toBe(true);
                 expect(this.player1.player.getDynastyCardsInProvince(rebirthLocation).every(card => card.facedown === false)).toBe(true);
+                expect(this.cycleOfRebirth.location).not.toBe('dynasty discard pile');
+            });
+
+            it('should shuffle Cycle of Rebirth and targeted card back into the deck - enemy', function() {
+                this.player1.clickCard(this.cycleOfRebirth);
+
+                expect(this.player1).toHavePrompt('Cycle of Rebirth');
+                this.player1.clickCard(this.yokuni);
+
+                expect(this.getChatLogs(10)).toContain('player1 plays Cycle of Rebirth to shuffle Togashi Yokuni into player2\'s dynasty deck. Cycle of Rebirth is shuffled into player1\'s dynasty deck');
+                expect(this.getChatLogs(3)).toContain('player1 is shuffling their dynasty deck');
+                expect(this.getChatLogs(3)).toContain('player2 is shuffling their dynasty deck');
                 expect(this.cycleOfRebirth.location).not.toBe('dynasty discard pile');
             });
         });

--- a/test/server/cards/14.1-RaW/CycleOfRebirth.spec.js
+++ b/test/server/cards/14.1-RaW/CycleOfRebirth.spec.js
@@ -84,6 +84,7 @@ describe('Cycle of Rebirth', function() {
                 expect(this.getChatLogs(3)).toContain('player1 is shuffling their dynasty deck');
                 expect(this.getChatLogs(3)).toContain('player2 is shuffling their dynasty deck');
                 expect(this.cycleOfRebirth.location).not.toBe('dynasty discard pile');
+                expect(this.yokuni.location).not.toBe('dynasty discard pile');
             });
         });
     });

--- a/test/server/cards/14.1-RaW/FieldOfRuin.spec.js
+++ b/test/server/cards/14.1-RaW/FieldOfRuin.spec.js
@@ -10,6 +10,8 @@ describe('Field of Ruin', function() {
                         provinces: ['ancestral-lands', 'manicured-garden']
                     },
                     player2: {
+                        dynastyDiscard: ['kakita-toshimoko', 'doji-challenger', 'kakita-yoshi'],
+                        provinces: ['entrenched-position']
                     }
                 });
 
@@ -19,15 +21,19 @@ describe('Field of Ruin', function() {
                 this.fieldOfRuin = this.player1.findCardByName('field-of-ruin');
                 this.ancestralLands = this.player1.findCardByName('ancestral-lands');
 
+                this.toshimoko = this.player2.placeCardInProvince('kakita-toshimoko', 'province 1');
+                this.challenger = this.player2.moveCard('doji-challenger', 'province 1');
+                this.yoshi = this.player2.moveCard('kakita-yoshi', 'province 1');
+                this.entrenched = this.player2.findCardByName('entrenched-position');
+
                 this.player1.clickPrompt('1');
                 this.player2.clickPrompt('1');
-
-                this.player1.playAttachment(this.fieldOfRuin, this.ancestralLands);
-
-                this.noMoreActions();
             });
 
             it('should trigger at the start of the conflict phase', function() {
+                this.player1.playAttachment(this.fieldOfRuin, this.ancestralLands);
+                this.noMoreActions();
+
                 expect(this.matsuBerseker.location).toBe('province 1');
                 expect(this.whisperer.location).toBe('province 1');
                 expect(this.zentaro.location).toBe('province 1');
@@ -36,7 +42,10 @@ describe('Field of Ruin', function() {
                 expect(this.player1).toBeAbleToSelect(this.fieldOfRuin);
             });
 
-            it('should discard each card in the province', function() {
+            it('should discard each card in the province - my province', function() {
+                this.player1.playAttachment(this.fieldOfRuin, this.ancestralLands);
+                this.noMoreActions();
+
                 expect(this.matsuBerseker.location).toBe('province 1');
                 expect(this.whisperer.location).toBe('province 1');
                 expect(this.zentaro.location).toBe('province 1');
@@ -49,7 +58,25 @@ describe('Field of Ruin', function() {
                 expect(this.whisperer.location).toBe('dynasty discard pile');
                 expect(this.zentaro.location).toBe('dynasty discard pile');
             });
+
+            it('should discard each card in the province - opponent\'s province', function() {
+                this.player1.playAttachment(this.fieldOfRuin, this.entrenched);
+                this.noMoreActions();
+
+                expect(this.toshimoko.location).toBe('province 1');
+                expect(this.challenger.location).toBe('province 1');
+                expect(this.yoshi.location).toBe('province 1');
+
+                expect(this.player1).toHavePrompt('Triggered Abilities');
+                expect(this.player1).toBeAbleToSelect(this.fieldOfRuin);
+                this.player1.clickCard(this.fieldOfRuin);
+
+                expect(this.toshimoko.location).toBe('dynasty discard pile');
+                expect(this.challenger.location).toBe('dynasty discard pile');
+                expect(this.yoshi.location).toBe('dynasty discard pile');
+            });
         });
+
         describe('Field of Ruin as a province attachment', function() {
             beforeEach(function() {
                 this.setupTest({


### PR DESCRIPTION
Handles Field of Ruin not discarding opponent's cards.

Handles Cycle of Rebirth not shuffling opponent's deck.