### PR TITLE
Bugfix - Starting game with less than 4 provinces

### DIFF
--- a/server/game/gamesteps/setup/setupprovincesprompt.js
+++ b/server/game/gamesteps/setup/setupprovincesprompt.js
@@ -97,7 +97,7 @@ class SetupProvincesPrompt extends AllPlayerPrompt {
         this.clickedDone[player.uuid] = true;
         this.game.addMessage('{0} has placed their provinces', player);
         player.moveCard(this.strongholdProvince[player.uuid], Locations.StrongholdProvince);
-        let provinces = this.selectedCards[player.uuid].concat(_.shuffle(this.selectableCards[player.uuid]));
+        let provinces = _.uniq(this.selectedCards[player.uuid].concat(_.shuffle(this.selectableCards[player.uuid])));
         for(let i = 1; i < 5; i++) {
             let provinceCard = provinces[i - 1];
             if(!provinceCard.startsGameFaceup()) {

--- a/test/server/integration/setup.spec.js
+++ b/test/server/integration/setup.spec.js
@@ -104,6 +104,23 @@ describe('setup phase', function() {
                 expect(strongholdProvince.location).toBe('stronghold province');
                 expect(this.player1.player.provinceDeck.size()).toBe(0);
             });
+
+            it('should allow players to place provinces in an order of their choice - selecting less than 4 provinces', function() {
+                let strongholdProvince = this.player1.player.provinceDeck.value()[0];
+                this.player1.clickCard(strongholdProvince);
+                expect(this.player1).toHavePrompt('Choose province order, or press Done to place them at random');
+                let provinces = this.player1.player.provinceDeck.value();
+                for(let i = 1; i < 3; i++) {
+                    this.player1.clickCard(provinces[i]);
+                }
+                this.player1.clickPrompt('Done');
+                for(let i = 1; i < 3; i++) {
+                    expect(provinces[i].location).toBe('province ' + i.toString());
+                }
+                expect(this.player1.currentPrompt().menuTitle).toBe('Waiting for opponent to finish selecting provinces');
+                expect(strongholdProvince.location).toBe('stronghold province');
+                expect(this.player1.player.provinceDeck.size()).toBe(0);
+            });
         });
 
         describe('dynasty mulligans', function() {


### PR DESCRIPTION
SelectableCards contains all provinces (since you can click on it to deselect and de-order).  As a result, you run into issues where the same province is being put into two provinces, leaving you with an empty one.

Closes #274