### PR TITLE
Master Tactician should not show cards during declaration.

### DIFF
--- a/server/game/conflict.js
+++ b/server/game/conflict.js
@@ -182,7 +182,7 @@ class Conflict extends GameObject {
     }
 
     isParticipating(card) {
-        return this.isAttacking(card) || this.isDefending(card);
+        return (this.isAttacking(card) || this.isDefending(card)) && this.declarationComplete;
     }
 
     anyParticipants(predicate) {

--- a/test/server/cards/14.3-IPoT/MasterTactician.spec.js
+++ b/test/server/cards/14.3-IPoT/MasterTactician.spec.js
@@ -309,6 +309,15 @@ describe('Master Tactician', function() {
             this.player1.clickCard(this.voice);
             expect(this.getChatLogs(3)).toContain('player1 plays a card from their conflict deck due to the ability of Master Tactician (0 uses remaining)');
         });
+
+        it('Should not let you see the card until after you commit to the conflict', function() {
+            this.player1.clickCard(this.ambush);
+            this.player1.clickCard(this.province);
+            this.noMoreActions();
+            this.player1.clickCard(this.tactician);
+            expect(this.player1.player.isTopConflictCardShown(this.player1.player)).toBe(false);
+            expect(this.player1.player.isTopConflictCardShown(this.player2.player)).toBe(false);
+        });
     });
 });
 


### PR DESCRIPTION
First interaction that shows we have a long standing bug where attackers and defenders are considered participating during declaration and not after successful declaration.

closes #441 