### PR TITLE
Bugfix - Covert at Kuni Wasteland using during-declaration targeting

### DIFF
--- a/server/game/gamesteps/conflict/conflictflow.js
+++ b/server/game/gamesteps/conflict/conflictflow.js
@@ -210,12 +210,12 @@ class ConflictFlow extends BaseStepWithPipeline {
         }));
         contexts = contexts.filter(context => context.source.canInitiateKeywords(context));
 
-        if(contexts.length === 0) {
-            return;
-        }
-
         for(let target of targets) {
             target.covert = false;
+        }
+
+        if(contexts.length === 0) {
+            return;
         }
 
         // Need to have:

--- a/test/server/cards/11-DoR/KuniWasteland.spec.js
+++ b/test/server/cards/11-DoR/KuniWasteland.spec.js
@@ -79,7 +79,22 @@ describe('Kuni Wasteland', function() {
                 expect(this.player1).toHavePrompt('Choose covert target for Iuchi Shahai');
             });
 
-            it('should not allow covert (if faceup)', function() {
+            it('should not allow covert (if faceup) - using post-declaration prompt', function() {
+                this.wasteland.facedown = false;
+                this.noMoreActions();
+                this.player1.clickRing('air');
+                this.player1.clickCard(this.wasteland);
+                this.player1.clickCard(this.shahai);
+                this.player1.clickCard(this.whisperer);
+                this.player1.clickPrompt('Initiate Conflict');
+                expect(this.player1).not.toHavePrompt('Choose covert target for Iuchi Shahai');
+                expect(this.player2).toHavePrompt('Choose defenders');
+                this.player2.clickCard(this.whisperer);
+                this.player2.clickPrompt('Done');
+                expect(this.game.currentConflict.defenders).toContain(this.whisperer);
+            });
+
+            it('should not allow covert (if faceup) - using in-declaration prompt', function() {
                 this.wasteland.facedown = false;
                 this.noMoreActions();
                 this.player1.clickRing('air');


### PR DESCRIPTION
Had to rearrange the control blocks at the start of the resolve covert method.