### PR TITLE
Fixed bug with Khan's Ordu

### DIFF
--- a/server/game/player.js
+++ b/server/game/player.js
@@ -326,7 +326,9 @@ class Player extends GameObject {
             return this.getConflictsWhenMaxIsSet(maxConflicts);
         }
         if(setConflictDeclarationType) {
-            return this.getRemainingConflictOpportunitiesForType(setConflictDeclarationType) - this.declaredConflictOpportunities[ConflictTypes.Passed];
+            return this.getRemainingConflictOpportunitiesForType(setConflictDeclarationType)
+                - this.declaredConflictOpportunities[ConflictTypes.Passed]
+                - this.declaredConflictOpportunities[ConflictTypes.Forced];
         }
 
         return this.getRemainingConflictOpportunitiesForType(ConflictTypes.Military)

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -326,7 +326,7 @@ class Player extends GameObject {
             return this.getConflictsWhenMaxIsSet(maxConflicts);
         }
         if(setConflictDeclarationType) {
-            return this.getRemainingConflictOpportunitiesForType(setConflictDeclarationType);
+            return this.getRemainingConflictOpportunitiesForType(setConflictDeclarationType) - this.declaredConflictOpportunities[ConflictTypes.Passed];
         }
 
         return this.getRemainingConflictOpportunitiesForType(ConflictTypes.Military)

--- a/test/server/cards/02.5-FHNS/WaningHostilities.spec.js
+++ b/test/server/cards/02.5-FHNS/WaningHostilities.spec.js
@@ -27,6 +27,19 @@ describe('Waning Hostilities', function() {
                 expect(this.player1.player.getConflictOpportunities()).toBe(1);
                 expect(this.player2.player.getConflictOpportunities()).toBe(1);
             });
+
+            it('passing conflicts should reduce the available conflict opportunities', function() {
+                this.player1.clickCard('waning-hostilities');
+                this.noMoreActions();
+                expect(this.player1.player.getConflictOpportunities()).toBe(1);
+                this.player1.passConflict();
+                expect(this.player1.player.getConflictOpportunities()).toBe(0);
+                this.noMoreActions();
+                this.player2.passConflict();
+                expect(this.player2.player.getConflictOpportunities()).toBe(0);
+                this.noMoreActions();
+                expect(this.player1).toHavePrompt('Which side of the Imperial Favor would you like to claim?');
+            });
         });
     });
 });

--- a/test/server/cards/07-WotW/KhansOrdu.spec.js
+++ b/test/server/cards/07-WotW/KhansOrdu.spec.js
@@ -67,6 +67,30 @@ describe('Khan\'s Ordu', function() {
                 expect(this.player2.player.getRemainingConflictOpportunitiesForType('political')).toBe(0);
                 expect(this.player2.player.getConflictOpportunities()).toBe(2);
             });
+
+            it('should work properly with conflict counting', function() {
+                this.noMoreActions();
+                this.initiateConflict({
+                    attackers: [this.akodoGunso],
+                    type: 'military'
+                });
+                this.player2.clickCard(this.khansOrdu);
+                this.player2.clickPrompt('Done');
+                this.noMoreActions();
+                this.player1.clickPrompt('Don\'t Resolve');
+                expect(this.player1.player.getRemainingConflictOpportunitiesForType('military')).toBe(1);
+                expect(this.player1.player.getRemainingConflictOpportunitiesForType('political')).toBe(0);
+                expect(this.player1.player.getConflictOpportunities()).toBe(1);
+                expect(this.player2.player.getRemainingConflictOpportunitiesForType('military')).toBe(2);
+                expect(this.player2.player.getRemainingConflictOpportunitiesForType('political')).toBe(0);
+                expect(this.player2.player.getConflictOpportunities()).toBe(2);
+
+                this.noMoreActions();
+                this.player2.passConflict();
+                expect(this.player2.player.getRemainingConflictOpportunitiesForType('military')).toBe(2);
+                expect(this.player2.player.getRemainingConflictOpportunitiesForType('political')).toBe(0);
+                expect(this.player2.player.getConflictOpportunities()).toBe(1);
+            });
         });
     });
 });


### PR DESCRIPTION
Passing conflicts with Khan's Ordu active wouldn't actually decrement your conflict opportunity, causing the game to get stuck with infinite conflict opportunities.