### PR TITLE
Bugfixes - Emperor with Nested Ability Resolutions

### DIFF
--- a/server/game/GameActions/ResolveAbilityAction.ts
+++ b/server/game/GameActions/ResolveAbilityAction.ts
@@ -79,6 +79,7 @@ export interface ResolveAbilityProperties extends CardActionProperties {
     ignoredRequirements?: string[];
     player?: Player;
     event?: Event;
+    choosingPlayerOverride?: Player;
 }
 
 export class ResolveAbilityAction extends CardGameAction {
@@ -86,7 +87,8 @@ export class ResolveAbilityAction extends CardGameAction {
     defaultProperties: ResolveAbilityProperties = {
         ability: null,
         ignoredRequirements: [],
-        subResolution: false
+        subResolution: false,
+        choosingPlayerOverride: null
     };
     constructor(properties: ((context: TriggeredAbilityContext) => ResolveAbilityProperties) | ResolveAbilityProperties) {
         super(properties);
@@ -116,6 +118,9 @@ export class ResolveAbilityAction extends CardGameAction {
         let newContextEvent = properties.event;
         let newContext = (properties.ability as TriggeredAbility).createContext(player, newContextEvent);
         newContext.subResolution = !!properties.subResolution;
+        if(properties.choosingPlayerOverride) {
+            newContext.choosingPlayerOverride = properties.choosingPlayerOverride;
+        }
         event.context.game.queueStep(new ResolveAbilityActionResolver(event.context.game, newContext, properties.ignoredRequirements.includes('cost')));
     }
 

--- a/server/game/cards/01-Core/Banzai.js
+++ b/server/game/cards/01-Core/Banzai.js
@@ -41,7 +41,13 @@ class Banzai extends DrawCard {
                     },
                     message: '{0} chooses {3}to lose an honor to resolve {1} again',
                     messageArgs: context => context.select === 'Done' ? 'not ' : '',
-                    then: { gameAction: AbilityDsl.actions.resolveAbility({ ability: context.ability instanceof CardAbility ? context.ability : null, subResolution: true }) }
+                    then: {
+                        gameAction: AbilityDsl.actions.resolveAbility({
+                            ability: context.ability instanceof CardAbility ? context.ability : null,
+                            subResolution: true,
+                            choosingPlayerOverride: context.choosingPlayerOverride
+                        })
+                    }
                 };
             }
         });

--- a/server/game/cards/02.6-MotE/ALegionOfOne.js
+++ b/server/game/cards/02.6-MotE/ALegionOfOne.js
@@ -43,7 +43,11 @@ class ALegionOfOne extends DrawCard {
                     messageArgs: context => context.select === 'Done' ? 'not ' : '',
                     then: {
                         thenCondition: event => event.origin === context.target && !event.cancelled && event.name === EventNames.OnMoveFate,
-                        gameAction: ability.actions.resolveAbility({ ability: context.ability, subResolution: true })
+                        gameAction: ability.actions.resolveAbility({
+                            ability: context.ability,
+                            subResolution: true,
+                            choosingPlayerOverride: context.choosingPlayerOverride
+                        })
                     }
                 };
             }

--- a/server/game/cards/06-CotE/HandToHand.js
+++ b/server/game/cards/06-CotE/HandToHand.js
@@ -21,7 +21,8 @@ class HandToHand extends DrawCard {
                         'Yes': ability.actions.resolveAbility({
                             ability: context.ability,
                             player: context.player.opponent ? context.player.opponent : context.player,
-                            subResolution: true
+                            subResolution: true,
+                            choosingPlayerOverride: context.choosingPlayerOverride
                         }),
                         'No': () => true
                     }

--- a/server/game/cards/09.4-TCoH/Overhear.js
+++ b/server/game/cards/09.4-TCoH/Overhear.js
@@ -47,7 +47,13 @@ class Overhear extends DrawCard {
                     },
                     message: '{0} chooses {3}to give an honor to {4} to resolve {1} again',
                     messageArgs: context => [context.select === 'Done' ? 'not ' : '', context.player.opponent],
-                    then: { gameAction: AbilityDsl.actions.resolveAbility({ ability: context.ability instanceof CardAbility ? context.ability : null, subResolution: true }) }
+                    then: {
+                        gameAction: AbilityDsl.actions.resolveAbility({
+                            ability: context.ability instanceof CardAbility ? context.ability : null,
+                            subResolution: true,
+                            choosingPlayerOverride: context.choosingPlayerOverride
+                        })
+                    }
                 };
             }
         });

--- a/server/game/cards/09.5-aCF/KeeperofSecretNames.js
+++ b/server/game/cards/09.5-aCF/KeeperofSecretNames.js
@@ -14,7 +14,8 @@ class KeeperOfSecretNames extends DrawCard {
                 gameAction: AbilityDsl.actions.resolveAbility(context => ({
                     target: context.target,
                     ability: context.target.abilities.actions[0],
-                    ignoredRequirements: ['province']
+                    ignoredRequirements: ['province'],
+                    choosingPlayerOverride: context.choosingPlayerOverride
                 }))
             }
         });

--- a/server/game/cards/14.1-RaW/CountrysideTrader.js
+++ b/server/game/cards/14.1-RaW/CountrysideTrader.js
@@ -12,7 +12,8 @@ class CountrysideTrader extends DrawCard {
                 return {
                     target: conflictProvince,
                     ability: conflictProvince.abilities.actions.concat(conflictProvince.abilities.reactions)[0],
-                    ignoredRequirements: ['condition']
+                    ignoredRequirements: ['condition'],
+                    choosingPlayerOverride: context.choosingPlayerOverride
                 };
             }),
             effect: 'resolve the province ability of {1}',

--- a/test/server/cards/01-Core/Banzai.spec.js
+++ b/test/server/cards/01-Core/Banzai.spec.js
@@ -171,5 +171,58 @@ describe('Banzai!', function() {
                 expect(this.player1.player.honor).toBe(9);
             });
         });
+
+        describe('With Emperor', function() {
+            beforeEach(function() {
+                this.setupTest({
+                    phase: 'conflict',
+                    player1: {
+                        inPlay: ['miya-mystic', 'seppun-guardsman'],
+                        hand: ['banzai']
+                    },
+                    player2: {
+                        inPlay: ['bayushi-manipulator', 'hantei-xxxviii']
+                    }
+                });
+                this.miyaMystic = this.player1.findCardByName('miya-mystic');
+                this.seppunGuardsman = this.player1.findCardByName('seppun-guardsman');
+                this.manipulator = this.player2.findCardByName('bayushi-manipulator');
+                this.banzai = this.player1.findCardByName('banzai');
+                this.hantei = this.player2.findCardByName('hantei-xxxviii');
+                this.noMoreActions();
+            });
+
+            it('should only work on participating characters', function() {
+                this.initiateConflict({
+                    type: 'military',
+                    attackers: [this.miyaMystic, this.seppunGuardsman],
+                    defenders: [this.manipulator]
+                });
+                this.player2.pass();
+                this.player1.clickCard(this.banzai);
+                expect(this.player1).toHavePrompt('Banzai!');
+                this.player1.clickCard(this.miyaMystic);
+                expect(this.player2).toHavePrompt('Triggered Abilities');
+                expect(this.player2).toBeAbleToSelect(this.hantei);
+                this.player2.clickCard(this.hantei);
+                expect(this.player2).toHavePrompt('Banzai!');
+                expect(this.player2).toBeAbleToSelect(this.miyaMystic);
+                expect(this.player2).toBeAbleToSelect(this.seppunGuardsman);
+                expect(this.player2).toBeAbleToSelect(this.manipulator);
+                expect(this.miyaMystic.getMilitarySkill()).toBe(1);
+
+                this.player2.clickCard(this.manipulator);
+                expect(this.manipulator.getMilitarySkill()).toBe(3);
+
+                this.player1.clickPrompt('Lose 1 honor to resolve this ability again');
+
+                expect(this.player2).toHavePrompt('Banzai!');
+                expect(this.player2).toBeAbleToSelect(this.miyaMystic);
+                expect(this.player2).toBeAbleToSelect(this.seppunGuardsman);
+                expect(this.player2).toBeAbleToSelect(this.manipulator);
+                this.player2.clickCard(this.manipulator);
+                expect(this.manipulator.getMilitarySkill()).toBe(5);
+            });
+        });
     });
 });


### PR DESCRIPTION
Fixing issues with the Emperor and nested ability resolutions.  He should be able to choose targets for all resolutions.