### PR TITLE
Potential Crash Fix

### DIFF
--- a/server/gamenode/gameserver.js
+++ b/server/gamenode/gameserver.js
@@ -201,8 +201,9 @@ class GameServer {
     onGameSync(callback) {
         var gameSummaries = _.map(this.games, game => {
             var retGame = game.getSummary();
-            retGame.password = game.password;
-
+            if(retGame) {
+                retGame.password = game.password;
+            }
             return retGame;
         });
 


### PR DESCRIPTION
This is a potential fix for the lobby crash also crashing games.

I tested this locally by crashing the lobby server, waiting a bit, and restarting it.  This would reproduce the `retGame.password = game.password;` error and crash the gamenode, ending the game.

After the fix, when I did the same steps, the game would survive - sometimes, players got booted to the lobby, but refreshing after that happened would bring you back into the game.

This might be a good stop-gap until we can figure out how to fix the lobby issues.