### PR TITLE
Honor from status token's message being displayed when no honor change

### DIFF
--- a/server/game/drawcard.js
+++ b/server/game/drawcard.js
@@ -652,11 +652,20 @@ class DrawCard extends BaseCard {
         }
 
         if(this.isDishonored && !this.anyEffect(EffectNames.HonorStatusDoesNotAffectLeavePlay)) {
-            this.game.addMessage('{0} loses 1 honor due to {1}\'s personal honor', this.controller, this);
-            this.game.openThenEventWindow(this.game.actions.loseHonor().getEvent(this.controller, this.game.getFrameworkContext()));
+            const frameworkContext = this.game.getFrameworkContext();
+            const honorLossAction = this.game.actions.loseHonor();
+
+            if(honorLossAction.canAffect(this.controller, frameworkContext)) {
+                this.game.addMessage('{0} loses 1 honor due to {1}\'s personal honor', this.controller, this);
+            }
+            this.game.openThenEventWindow(honorLossAction.getEvent(this.controller, frameworkContext));
         } else if(this.isHonored && !this.anyEffect(EffectNames.HonorStatusDoesNotAffectLeavePlay)) {
-            this.game.addMessage('{0} gains 1 honor due to {1}\'s personal honor', this.controller, this);
-            this.game.openThenEventWindow(this.game.actions.gainHonor().getEvent(this.controller, this.game.getFrameworkContext()));
+            const frameworkContext = this.game.getFrameworkContext();
+            const honorGainAction = this.game.actions.gainHonor();
+            if(honorGainAction.canAffect(this.controller, frameworkContext)) {
+                this.game.addMessage('{0} gains 1 honor due to {1}\'s personal honor', this.controller, this);
+            }
+            this.game.openThenEventWindow(honorGainAction.getEvent(this.controller, frameworkContext));
         }
 
         this.makeOrdinary();

--- a/test/server/cards/14.3-IPoT/SilentOnesMonastery.spec.js
+++ b/test/server/cards/14.3-IPoT/SilentOnesMonastery.spec.js
@@ -210,5 +210,40 @@ describe('Silent Ones Monastery', function() {
                 expect(this.player1.honor).toBe(this.startingHonor + 2); // didn't gain the 2 full honor, but got up to the cap of the phase: 2.
             });
         });
+        describe('When more than 2 honored characters would leave play during the same phase,', function() {
+            beforeEach(function() {
+                this.setupTest({
+                    phase: 'conflict',
+                    player1: {
+                        honor: 11,
+                        inPlay: ['ikoma-prodigy', 'matsu-berserker', 'ikoma-orator']
+                    },
+                    player2: {
+                        provinces: ['silent-ones-monastery']
+                    }
+                });
+                this.prodigy = this.player1.findCardByName('ikoma-prodigy');
+                this.berserker = this.player1.findCardByName('matsu-berserker');
+                this.orator = this.player1.findCardByName('ikoma-orator');
+
+                this.orator.honor();
+                this.prodigy.honor();
+                this.berserker.honor();
+            });
+
+            it('should reward up to 2 honor.', function() {
+                this.startingHonor = this.player1.honor;
+
+                this.flow.finishConflictPhase();
+                this.player1.clickCard(this.orator);
+                this.player1.clickCard(this.prodigy);
+                this.player1.clickCard(this.berserker);
+
+                expect(this.getChatLogs(5)).toContain('player1 gains 1 honor due to Ikoma Prodigy\'s personal honor');
+                expect(this.getChatLogs(5)).toContain('player1 gains 1 honor due to Ikoma Orator\'s personal honor');
+                expect(this.getChatLogs(5)).not.toContain('player1 gains 1 honor due to Matsu Berserker\'s personal honor');
+                expect(this.player1.honor).toBe(this.startingHonor + 2); // Should only gain 2.
+            });
+        });
     });
 });


### PR DESCRIPTION
Make sure the message being displayed when characters leaves play takes into account whether honor can be gained